### PR TITLE
fix: Check MemberPk in delete board API

### DIFF
--- a/backend/slind/src/main/java/com/team2/slind/board/mapper/BoardMapper.java
+++ b/backend/slind/src/main/java/com/team2/slind/board/mapper/BoardMapper.java
@@ -9,4 +9,5 @@ public interface BoardMapper {
     void addBoard(Board board);
     Optional<Board> findByBoardTitle(String boardTitle);
     Long deleteByBoardPk(Long boardPk);
+    Optional<Board> findByBoardPk(Long boardPk);
 }

--- a/backend/slind/src/main/java/com/team2/slind/board/service/BoardService.java
+++ b/backend/slind/src/main/java/com/team2/slind/board/service/BoardService.java
@@ -5,6 +5,7 @@ import com.team2.slind.board.mapper.BoardMapper;
 import com.team2.slind.board.vo.Board;
 import com.team2.slind.common.exception.BoardNotFoundException;
 import com.team2.slind.common.exception.DuplicateTitleException;
+import com.team2.slind.common.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -41,6 +42,11 @@ public class BoardService {
     }
 
     public ResponseEntity deleteBoard(Long boardPk) {
+        Board board = boardMapper.findByBoardPk(boardPk).orElseThrow(()->
+                new BoardNotFoundException(BoardNotFoundException.BOARD_NOT_FOUND));
+        if (board.getMemberPk()!=memberPk){
+            throw new UnauthorizedException(UnauthorizedException.UNAUTHORIZED_DELETE_BOARD);
+        }
         Long result = boardMapper.deleteByBoardPk(boardPk);
         if (result == 0L){
             throw new BoardNotFoundException(BoardNotFoundException.BOARD_NOT_FOUND);

--- a/backend/slind/src/main/java/com/team2/slind/common/advice/GlobalExceptionHandler.java
+++ b/backend/slind/src/main/java/com/team2/slind/common/advice/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.team2.slind.common.advice;
 
 import com.team2.slind.common.exception.BoardNotFoundException;
 import com.team2.slind.common.exception.DuplicateTitleException;
+import com.team2.slind.common.exception.UnauthorizedException;
 import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,13 +11,21 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    //400 Error
     @ExceptionHandler({DuplicateTitleException.class})
     public ResponseEntity handleDuplicateTitleException(Exception e) {
         return ResponseEntity.badRequest().body(e.getMessage());
     }
 
+    //404 Error
     @ExceptionHandler({BoardNotFoundException.class})
     public ResponseEntity handleNotFoundException(Exception e) {
         return ResponseEntity.status(404).body(e.getMessage());
+    }
+
+    //401 Error
+    @ExceptionHandler({UnauthorizedException.class})
+    public ResponseEntity handleUnauthorizedException(Exception e) {
+        return ResponseEntity.status(401).body(e.getMessage());
     }
 }

--- a/backend/slind/src/main/java/com/team2/slind/common/exception/UnauthorizedException.java
+++ b/backend/slind/src/main/java/com/team2/slind/common/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.team2.slind.common.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public static final String UNAUTHORIZED_DELETE_BOARD = "게시판 삭제 권한이 없는 계정입니다.";
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend/slind/src/main/resources/com/team2/slind/board/mapper/BoardMapper.xml
+++ b/backend/slind/src/main/resources/com/team2/slind/board/mapper/BoardMapper.xml
@@ -11,6 +11,10 @@
         SELECT * FROM tbl_board WHERE title = #{title}
     </select>
 
+    <select id="findByBoardPk" parameterType="Long" resultType="Board">
+        SELECT * FROM tbl_board WHERE board_pk = #{boardPk}
+    </select>
+
     <update id="deleteByBoardPk" parameterType="Long">
         UPDATE tbl_board
         SET is_deleted = 1, deleted_dttm = SYSDATE


### PR DESCRIPTION

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Board를 생성한 멤버와 삭제할 멤버가 일치하지 않을 경우에도 삭제되는 상황을 방지하기 위함
<!---- Resolves: #(Isuue Number) -->

## PR 유형
- Board 생성자와 로그인 유저 확인후 예외처리 추가


- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## Issue Closed
닫을 이슈 번호를 입력해주세요 (ex. close #)
close #4 
close #2 